### PR TITLE
Use 'with' / contextlib for zip files, add missing test results folders

### DIFF
--- a/geopublisher/geopublisher.py
+++ b/geopublisher/geopublisher.py
@@ -71,14 +71,12 @@ def create_archive(archive_folder, output_file):
     print 'Archiving %s to %s' % (output_file, archive_filepath)
     output_desc = arcpy.Describe(output_file)
     try:
-        zf = zipfile.ZipFile(archive_filepath, mode='w',
-                             compression=zipfile.ZIP_DEFLATED)
-        shape_zipper(output_file, zf)
+        with zipfile.ZipFile(archive_filepath, mode='w',
+                             compression=zipfile.ZIP_DEFLATED) as zf:
+            shape_zipper(output_file, zf)
+            zip_info(zf)
     except arcpy.ExecuteError as e:
         raise e
-    finally:
-        zf.close()
-        zip_info(zf)
 
 
 def shape_zipper(shapefile, zip):

--- a/tests/results/Results_Archive/.blank
+++ b/tests/results/Results_Archive/.blank
@@ -1,0 +1,1 @@
+blank file to force Git to add this directory.

--- a/tests/results/Results_Shapefiles/.blank
+++ b/tests/results/Results_Shapefiles/.blank
@@ -1,0 +1,1 @@
+blank file to force Git to add this directory.

--- a/tests/test_geopublisher.py
+++ b/tests/test_geopublisher.py
@@ -211,15 +211,15 @@ class TestGeopublisher(unittest.TestCase):
         shapefile = os.path.join(self.testShpWorkspace, 'Airports.shp')
         testZipFile = os.path.join(self.archiveWorkspace, 'testZip.zip')
         try:
-            zf = zipfile.ZipFile(testZipFile, mode='w',
-                                 compression=zipfile.ZIP_DEFLATED)
-            geopublisher.shape_zipper(shapefile, zf)
+            with zipfile.ZipFile(testZipFile, mode='w',
+                                 compression=zipfile.ZIP_DEFLATED) as zf:
+
+                geopublisher.shape_zipper(shapefile, zf)
+
+                archiveFiles = zf.namelist()
+                self.assertNotIn('Airports.mxd', archiveFiles)
         except arcpy.ExecuteError as e:
             raise e
-        finally:
-            zf.close()
-        archiveFiles = zf.namelist()
-        self.assertNotIn('Airports.mxd', archiveFiles)
 
     def tearDown(self):
         """


### PR DESCRIPTION
Hi @npeihl, just a couple of minor changes:

- Added two missing directories. Because Git doesn't support adding empty directories, I've added 'stub' files to the directories so they get picked up correctly. Without these directories, most of the tests were failing.
- When the tests failed, the `zf` object couldn't be properly referenced in the `finally` blocks. I've switched to the contextlib / with syntax which avoids this issue and has other advantages.

Otherwise, the tests worked great -- I couldn't run the SDE ones, but the rest worked fine. I also had some issues with `tox`, but that may be on my end. The tests ran fine just using nose directly. 